### PR TITLE
解决使用"-race"进行竞态检查报错

### DIFF
--- a/router.go
+++ b/router.go
@@ -488,11 +488,9 @@ func makeCallHandlersFromStruct(prefix string, callCtrlStruct interface{}, plugi
 	var pool = &sync.Pool{
 		New: func() interface{} {
 			ctrl := reflect.New(ctypeElem)
-			callCtxPtr := ctrl.Pointer() + callCtxOffset
-			ctxPtr := (*CallCtx)(unsafe.Pointer(callCtxPtr))
 			return &CallCtrlValue{
 				ctrl:   ctrl,
-				ctxPtr: ctxPtr,
+				ctxPtr: (*CallCtx)(unsafe.Pointer(uintptr(unsafe.Pointer(ctrl.Pointer())) + callCtxOffset)),
 			}
 		},
 	}
@@ -674,11 +672,9 @@ func makeCallHandlersFromFunc(prefix string, callHandleFunc interface{}, pluginC
 		var pool = &sync.Pool{
 			New: func() interface{} {
 				ctrl := reflect.New(ctxTypeElem)
-				callCtxPtr := ctrl.Pointer() + callCtxOffset
-				ctxPtr := (*CallCtx)(unsafe.Pointer(callCtxPtr))
 				return &CallCtrlValue{
 					ctrl:   ctrl,
-					ctxPtr: ctxPtr,
+					ctxPtr: (*CallCtx)(unsafe.Pointer(uintptr(unsafe.Pointer(ctrl.Pointer())) + callCtxOffset)),
 				}
 			},
 		}
@@ -743,11 +739,9 @@ func makePushHandlersFromStruct(prefix string, pushCtrlStruct interface{}, plugi
 	var pool = &sync.Pool{
 		New: func() interface{} {
 			ctrl := reflect.New(ctypeElem)
-			pushCtxPtr := ctrl.Pointer() + pushCtxOffset
-			ctxPtr := (*PushCtx)(unsafe.Pointer(pushCtxPtr))
 			return &PushCtrlValue{
 				ctrl:   ctrl,
-				ctxPtr: ctxPtr,
+				ctxPtr: (*PushCtx)(unsafe.Pointer(uintptr(unsafe.Pointer(ctrl.Pointer())) + pushCtxOffset)),
 			}
 		},
 	}
@@ -902,11 +896,9 @@ func makePushHandlersFromFunc(prefix string, pushHandleFunc interface{}, pluginC
 		var pool = &sync.Pool{
 			New: func() interface{} {
 				ctrl := reflect.New(ctxTypeElem)
-				pushCtxPtr := ctrl.Pointer() + pushCtxOffset
-				ctxPtr := (*PushCtx)(unsafe.Pointer(pushCtxPtr))
 				return &PushCtrlValue{
 					ctrl:   ctrl,
-					ctxPtr: ctxPtr,
+					ctxPtr: (*PushCtx)(unsafe.Pointer(uintptr(unsafe.Pointer(ctrl.Pointer())) + pushCtxOffset)),
 				}
 			},
 		}


### PR DESCRIPTION
重现方法

打开命令行窗口：
```
cd /path/to/examples/simple/
go run -race server.go
```
打开第二个命令行窗口
```
cd /path/to/examples/simple/
go run -race client.go
```
此时第一个窗口必定会报错。
> fatal error: checkptr: pointer arithmetic result points to invalid allocation

错误原因，不正确的使用了unsafe包，将非类型安全指针转换为一个uintptr值，然后此uintptr值参与各种算术运算，再将算术运算的结果uintptr值转回非类型安全指针。

使用说明可以参考，https://blog.csdn.net/u010853261/article/details/103826830

使用该pr修复后，执行成功。

